### PR TITLE
Fixed that the test error ends in site-package

### DIFF
--- a/autoload/vim_python_test_runner.vim
+++ b/autoload/vim_python_test_runner.vim
@@ -1,5 +1,5 @@
 set makeprg=cat\ /tmp/test_results.txt
-set efm+=%C\ %.%#,%A\ \ File\ \"%f\"\\,\ line\ %l%.%#,%Z%[%^\ ]%\\@=%m
+set efm+=%-G%.%#lib/python%.%#/site-package%.%#,%C\ %.%#,%A\ \ File\ \"%f\"\\,\ line\ %l%.%#,%Z%[%^\ ]%\\@=%m
 
 if !has('python')
     finish


### PR DESCRIPTION
When the test method has a decorator for example mock.patch the error is shown in the mock.py module in the site-package and not in the underlying test case. This patch excludes the site-package from the stack-trace of the test-case exception.