### PR TITLE
Update Marker syntax for vim

### DIFF
--- a/autoload/vim_python_test_runner.vim
+++ b/autoload/vim_python_test_runner.vim
@@ -13,7 +13,7 @@ python3 import vim
 python3 sys.path.append(vim.eval('expand("<sfile>:h")'))
 
 function! vim_python_test_runner#RunDesiredTests(command_to_run)
-python3 << endPython
+python3 << EndPython
 import os
 from vim_python_test_runner import *
 
@@ -58,6 +58,6 @@ def main():
 
 vim.command('wall')
 main()
-endPython
+EndPython
 endfunction
 


### PR DESCRIPTION
Apparently in vim 8.2 (apparently) the heredoc syntax requires that the markers cannot be lower case and will result in an error like this:

Error detected while processing function vim_python_test_runner#RunDesiredTests:
line    1:
E221: Marker cannot start with lower case letter
  File "<string>", line 1
    << endPython
     ^
SyntaxError: invalid syntax
line    2:
E1042: import/export can only be used in vim9script
line    3:
E492: Not an editor command: from vim_python_test_runner import *
line    5:
E128: Function name must start with a capital or "s:": get_proper_command(desired_command, current_directory):
line    6:
E492: Not an editor command:     current_line_index = vim.current.window.cursor[0]
line    7:
E492: Not an editor command:     FUNCTIONS = {
line   21:
E492: Not an editor command:     }
line   22:
E121: Undefined variable: FUNCTIONS