### PR TITLE
Avoid throwing incorrect error after get_proper_command call fails

### DIFF
--- a/autoload/vim_python_test_runner.vim
+++ b/autoload/vim_python_test_runner.vim
@@ -53,8 +53,9 @@ def main():
         command_to_run = get_proper_command(vim.eval("a:command_to_run"), current_directory)
     except Exception as e:
         print(e)
-    run_desired_command_for_os(command_to_run)
-    vim.command('silent make! | cw')
+    else:
+        run_desired_command_for_os(command_to_run)
+        vim.command('silent make! | cw')
 
 vim.command('wall')
 main()


### PR DESCRIPTION
If get_proper_command raises Exception command_to_run is undefined causing interpreter to raise
local variable referenced before assignment error.